### PR TITLE
Add support for timeout in function kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+.ropeproject/

--- a/requirements
+++ b/requirements
@@ -1,0 +1,3 @@
+argparse==1.2.1
+nose==1.3.4
+wsgiref==0.1.2

--- a/tests/test_timeout_decorator.py
+++ b/tests/test_timeout_decorator.py
@@ -2,14 +2,38 @@
 # -*- coding: utf-8 -*-
 
 import time
-import timeout_decorator 
 
-@timeout_decorator.timeout(5)
-def mytest():
-    print "Start"
-    for i in range(1,10):
+from nose.tools import raises
+
+from timeout_decorator import timeout, TimeoutError
+
+
+@raises(TimeoutError)
+def test_timeout_decorator_arg():
+    @timeout(1)
+    def f():
+        time.sleep(2)
+    f()
+
+
+@raises(TimeoutError)
+def test_timeout_kwargs():
+    @timeout()
+    def f(timeout):
+        time.sleep(2)
+    f(timeout=1)
+
+
+@raises(ValueError)
+def test_timeout_no_seconds():
+    @timeout()
+    def f(timeout):
+        time.sleep(2)
+    f()
+
+
+def test_timeout_ok():
+    @timeout(seconds=2)
+    def f():
         time.sleep(1)
-        print "%d seconds have passed" % i
-
-if __name__ == '__main__':
-    mytest()
+    f()

--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -18,19 +18,28 @@ import signal
 
 #http://www.saltycrane.com/blog/2010/04/using-python-timeout-decorator-uploading-s3/
 
+
 class TimeoutError(Exception):
-    def __init__(self, value = "Timed Out"):
+    def __init__(self, value="Timed Out"):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
 
-def timeout(seconds_before_timeout):
+
+def timeout(seconds=None):
     def decorate(f):
         def handler(signum, frame):
             raise TimeoutError()
+
         def new_f(*args, **kwargs):
             old = signal.signal(signal.SIGALRM, handler)
-            signal.alarm(seconds_before_timeout)
+
+            new_seconds = kwargs['timeout'] if 'timeout' in kwargs else seconds
+            if new_seconds is None:
+                raise ValueError("You must provide a timeout value")
+
+            signal.alarm(new_seconds)
             try:
                 result = f(*args, **kwargs)
             finally:


### PR DESCRIPTION
I've added support for passing the timeout in kwargs, which means the client
code can decide the timeout. This is useful for functions that take a timeout
argument.

I've also made the tests proper and added nosetests as a requirement.

I'm not 100% sure about the implementation, so your feedback is appreciated.
