### PR TITLE
Use functools.wraps in decorator

### DIFF
--- a/tests/test_timeout_decorator.py
+++ b/tests/test_timeout_decorator.py
@@ -37,3 +37,11 @@ def test_timeout_ok():
     def f():
         time.sleep(1)
     f()
+
+
+def test_function_name():
+    @timeout(seconds=2)
+    def func_name():
+        pass
+
+    assert func_name.__name__ == 'func_name'

--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import signal
+from functools import wraps
 
 ############################################################
 # Timeout
@@ -32,6 +33,7 @@ def timeout(seconds=None):
         def handler(signum, frame):
             raise TimeoutError()
 
+        @wraps(f)
         def new_f(*args, **kwargs):
             old = signal.signal(signal.SIGALRM, handler)
 
@@ -46,6 +48,5 @@ def timeout(seconds=None):
                 signal.signal(signal.SIGALRM, old)
             signal.alarm(0)
             return result
-        new_f.func_name = f.func_name
         return new_f
     return decorate


### PR DESCRIPTION
- This will ensure that the func_name and doc_strings are correct across py versions
- Fixes issue #2 
