### PR TITLE
Make timeout error an assertion error, not just any old exception

### DIFF
--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -20,7 +20,7 @@ from functools import wraps
 #http://www.saltycrane.com/blog/2010/04/using-python-timeout-decorator-uploading-s3/
 
 
-class TimeoutError(Exception):
+class TimeoutError(AssertionError):
     def __init__(self, value="Timed Out"):
         self.value = value
 


### PR DESCRIPTION
This means that timeout failures are considered to be test failures, where a specific assertion (i.e. 'this function takes less than N seconds') has failed, rather than being a random error in the test that may indicate a bug.