### PR TITLE
Fix 0.2.0 release: include README.md that's missing from the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE tests/*.py
+include README.md LICENSE tests/*.py


### PR DESCRIPTION
Sorry to keep opening issues!

The new 0.2.0 release doesn't install, because it needs a README.md file rather than README.rst, as of https://github.com/pnpnpn/timeout-decorator/commit/9f302a455aaefd0b5397d4f9f5183f22af88b2f1, and that file isn't included in the package itself. This adds it to the package.

I think this is correct, but I'm not actually really that familiar with Python packaging, so I'm basically guessing. Looks likely though, to my eye.

In case it's useful, the actual error is:

```bash
(venv)vagrant@vagrant-ubuntu-trusty-64:/vagrant$ pip install timeout-decorator                               
Collecting timeout-decorator                                                                                 
  Using cached timeout-decorator-0.2.0.tar.gz                                                                
    Traceback (most recent call last):                                                                       
      File "<string>", line 20, in <module>                                                                  
      File "/tmp/pip-build-01qb3sk9/timeout-decorator/setup.py", line 24, in <module>                        
        long_description = open('README.md').read(),                                                         
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'                                      
    Complete output from command python setup.py egg_info:                                                   
    Traceback (most recent call last):                                                                       
                                                                                                             
      File "<string>", line 20, in <module>                                                                  
                                                                                                             
      File "/tmp/pip-build-01qb3sk9/timeout-decorator/setup.py", line 24, in <module>                        
                                                                                                             
        long_description = open('README.md').read(),                                                         
                                                                                                             
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'                                      
                                                                                                             
    ----------------------------------------                                                                 
    Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-01qb3sk9/timeout-decorator 
```