### PR TITLE
Unset alarm before removing SIGALRM handler

### DIFF
--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -45,8 +45,8 @@ def timeout(seconds=None):
             try:
                 result = f(*args, **kwargs)
             finally:
+                signal.alarm(0)
                 signal.signal(signal.SIGALRM, old)
-            signal.alarm(0)
             return result
         return new_f
     return decorate


### PR DESCRIPTION
In situations where an exception is thrown, the alarm wouldn't be unset even if the handler was removed. This results in program termination.