### PR TITLE
Use signal.setitimer to allow setting sub-second timeouts.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ long_description = (
 
 setup(
     name='timeout-decorator',
-    version='0.3.1',
+    version='0.3.2',
     description='Timeout decorator',
     long_description=long_description,
     author='Patrick Ng',

--- a/tests/test_timeout_decorator.py
+++ b/tests/test_timeout_decorator.py
@@ -35,6 +35,14 @@ def test_timeout_no_seconds(use_signals):
     f()
 
 
+def test_timeout_partial_seconds(use_signals):
+    @timeout(0.2, use_signals=use_signals)
+    def f():
+        time.sleep(0.5)
+    with pytest.raises(TimeoutError):
+        f()
+
+
 def test_timeout_ok(use_signals):
     @timeout(seconds=2, use_signals=use_signals)
     def f():

--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -40,7 +40,7 @@ def timeout(seconds=None, use_signals=True):
 
     :param seconds: optional time limit in seconds. If None is passed, no timeout is applied.
         This adds some flexibility to the usage: you can disable timing out depending on the settings.
-    :type seconds: int
+    :type seconds: float
     :param use_signals: flag indicating whether signals should be used for timing function out or the multiprocessing
     :type use_signals: bool
 
@@ -63,12 +63,12 @@ def timeout(seconds=None, use_signals=True):
                 new_seconds = kwargs.pop('timeout', seconds)
                 if new_seconds:
                     old = signal.signal(signal.SIGALRM, handler)
-                    signal.alarm(new_seconds)
+                    signal.setitimer(signal.ITIMER_REAL, new_seconds)
                 try:
                     return function(*args, **kwargs)
                 finally:
                     if new_seconds:
-                        signal.alarm(0)
+                        signal.setitimer(signal.ITIMER_REAL, 0)
                         signal.signal(signal.SIGALRM, old)
             return new_function
         else:

--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -38,10 +38,11 @@ class TimeoutError(AssertionError):
 def timeout(seconds=None, use_signals=True):
     """Add a timeout parameter to a function and return it.
 
-    :param seconds: optional time limit in seconds. If None is passed, no timeout is applied.
+    :param seconds: optional time limit in seconds or fractions of a second. If None is passed, no timeout is applied.
         This adds some flexibility to the usage: you can disable timing out depending on the settings.
     :type seconds: float
     :param use_signals: flag indicating whether signals should be used for timing function out or the multiprocessing
+        When using multiprocessing, timeout granularity is limited to 10ths of a second.
     :type use_signals: bool
 
     :raises: TimeoutError if time limit is reached


### PR DESCRIPTION
I think this is an easy change to allow sub-second timeouts, using setitimer instead of alarm. It is limited by the granularity of the sleep in the _Timer, but still seems useful!

