### PR TITLE
Allow to use timeout in function kwargs even when initial seconds is None

### DIFF
--- a/tests/test_timeout_decorator.py
+++ b/tests/test_timeout_decorator.py
@@ -28,6 +28,14 @@ def test_timeout_kwargs(use_signals):
         f(timeout=1)
 
 
+def test_timeout_kwargs_with_initial_timeout_none(use_signals):
+    @timeout(use_signals=use_signals)
+    def f():
+        time.sleep(2)
+    with pytest.raises(TimeoutError):
+        f(timeout=1)
+
+
 def test_timeout_no_seconds(use_signals):
     @timeout(use_signals=use_signals)
     def f():


### PR DESCRIPTION
Initial support for timeout in function kwargs was implemented by 187ee34d9e0a571bcc7f9233208462634940f4c0
