### PR TITLE
Add additional python versions to CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: python
+sudo: false
 python:
+- '2.6'
 - '2.7'
+- '3.2'
+- '3.3'
+- '3.4'
+- '3.5'
+- '3.6'
 install:
-- pip install python-coveralls virtualenv tox
-script: tox
+- if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install -U "virtualenv<14.0.0"; fi
+- pip install python-coveralls tox tox-travis
+script: tox --recreate
 after_success:
-- pip install -r requirements-testing.txt -e .
+- pip install -e .
 - py.test --cov=timeout_decorator --cov-report=term-missing tests
 - coveralls
 deploy:

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,2 +1,0 @@
-pytest==2.6.4
-pytest-pep8==1.0.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,17 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=py26,py27,py32,py33,py34
+envlist=py{26,27,32,33,34,35,36}
 skip_missing_interpreters=true
 indexserver=
     pypi = https://pypi.python.org/simple
 
 [testenv]
-commands= py.test timeout_decorator tests --pep8
-deps = -r{toxinidir}/requirements-testing.txt
+commands=
+    py.test timeout_decorator tests --pep8
+deps = 
+    py32: pytest<3.0
+    py{26,27,33,34,35,36}: pytest>=3.0
+    pytest-pep8==1.0.6
 
 [pytest]
 addopts = -vvl


### PR DESCRIPTION
 - Add Python 3.5 and 3.6 to tested versions in tox.ini
 - Add individual python versions to .travis.yml to take advantage of
   Travis-CI's parallel testing
 - Bump py.test version to support Python 3.5 and 3.6 testing
 - Migrate from Travis-CI's legacy infrastructure to container infrastructure
    by adding `sudo: false` to .travis.yml
 - virtualenv >= 14.0.0 removed support for python 3.2. Add conditional installation
   of virtualenv and py.test for 3.2 environments