### PR TITLE
#62 solve celery incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
     author_email='pn.appdev@gmail.com',
     url='https://github.com/pnpnpn/timeout-decorator',
     packages=['timeout_decorator'],
-    install_requires=[],
+    install_requires=['billiard'],
     classifiers=CLASSIFIERS)

--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 import sys
 import time
-import multiprocessing
+import billiard as multiprocessing
 import signal
 from functools import wraps
 


### PR DESCRIPTION
Replaces `multiprocess` by `billiard`

Tested on python 2.7 and 3.5