### PR TITLE
Terminate and join all child processes

### DIFF
--- a/timeout_decorator/timeout_decorator.py
+++ b/timeout_decorator/timeout_decorator.py
@@ -149,12 +149,16 @@ class _Timeout(object):
             self.__timeout = self.__limit + time.time()
         while not self.ready:
             time.sleep(0.01)
-        return self.value
+        result = self.value
+        self.__process.terminate()
+        self.__process.join()
+        return result
 
     def cancel(self):
         """Terminate any possible execution of the embedded function."""
         if self.__process.is_alive():
             self.__process.terminate()
+            self.__process.join()
 
         _raise_exception(self.__timeout_exception, self.__exception_message)
 


### PR DESCRIPTION
When using multiprocessing to time the function, we need to eventually terminate the process even if the function succeeds. I believe it is also a good practice to join the process in the end.

This resolved an error I was running across, namely: `OSError: [Errno 24] Too many open files`.